### PR TITLE
Add adsb.one back to external

### DIFF
--- a/manifests/default/external/default/kustomization.yaml
+++ b/manifests/default/external/default/kustomization.yaml
@@ -9,7 +9,7 @@ patches:
       path: /spec/template/spec/containers/0/env/-
       value:
         name: READSB_NET_CONNECTOR
-        value: "cnvr.io,30005,beast_out"
+        value: "cnvr.io,30005,beast_out;feed.adsb.one,64005,beast_out"
     - op: add
       path: /spec/template/spec/containers/0/env/-
       value:


### PR DESCRIPTION
Separate readsb instance at adsb.one has been created for ingest from external aggregators on port 64005.